### PR TITLE
PAY-7365: Pipeline fixes - week beginning 23nd October 2024

### DIFF
--- a/acceptance-tests/test/end-to-end/tests/CCPB_BulkScanFunctionality_test.js
+++ b/acceptance-tests/test/end-to-end/tests/CCPB_BulkScanFunctionality_test.js
@@ -431,4 +431,4 @@ Scenario('Download reports in paybubble', ({ I, Reports }) => {
   Reports.selectReportAndDownload('Processed unallocated');
   Reports.selectReportAndDownload('Under payment and Over payment');
   I.Logout();
-}).tag('@nightly');
+})


### PR DESCRIPTION
 PAY-7365: Pipeline fixes - week beginning 23nd October 2024
    [PAY-7365] (https://tools.hmcts.net/jira/browse/PAY-7365).

